### PR TITLE
Consume current_user route and RFC on get_shuttles and like routes

### DIFF
--- a/routes/get_shuttles.js
+++ b/routes/get_shuttles.js
@@ -15,7 +15,8 @@ router.get('/', function(req, res) {
 	if (helper.isAdmin(rcs_id)) {
 		var query = Shuttle.find({}).lean();
 		query.exec(function(err, docs) {
-			res.send(docs);
+
+			res.send({"data":docs});
 		});
 	} else {
 		var query = Shuttle.find({}).lean();

--- a/web/app/dashboard/dashboard.component.ts
+++ b/web/app/dashboard/dashboard.component.ts
@@ -1,14 +1,22 @@
 import { Component } from '@angular/core';
+import { Observable }       from 'rxjs/Observable';
 import { DashboardService } from './dashboard.service';
 import {User} from './user';
 @Component({
     selector: 'shuttle-dashboard',
-    templateUrl: 'views/partials/dashboard.html'
+    templateUrl: 'views/partials/dashboard.html',
+    providers: [DashboardService]
 })
 
 export class DashboardComponent {
   public user: User;
-  constructor(){
-    this.user = new User("Lucien","brulel");
+  public data: any;
+  public d_user: any;
+  public d_error: any;
+  constructor(private dashboardService: DashboardService){
+    this.user = new User("Shirley","001RPI");
+    this.dashboardService.getUser().then(user =>this.user = user);
+    this.data = this.dashboardService.getUser();
+    console.log("Made a Component");
   }
 }

--- a/web/app/dashboard/dashboard.module.ts
+++ b/web/app/dashboard/dashboard.module.ts
@@ -1,9 +1,13 @@
 import { NgModule }      from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { DashboardComponent }   from './dashboard.component';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+// import { FormsModule } from '@angular/forms';
+import { HttpModule, JsonpModule } from '@angular/http';
 @NgModule({
-  imports:      [ BrowserModule ],
-  declarations: [ DashboardComponent ],
-  bootstrap:    [ DashboardComponent ]
+    imports: [BrowserModule, HttpModule, JsonpModule],
+    declarations: [DashboardComponent],
+    bootstrap: [DashboardComponent]
 })
 export class DashboardModule { }
+platformBrowserDynamic().bootstrapModule(DashboardModule);

--- a/web/app/dashboard/dashboard.service.ts
+++ b/web/app/dashboard/dashboard.service.ts
@@ -1,5 +1,51 @@
 import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+import { Observable }     from 'rxjs/Observable';
+import {User } from './user';
+// Statics
+import 'rxjs/add/observable/throw';
+
+// Operators
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/switchMap';
+import 'rxjs/add/operator/toPromise';
 
 @Injectable()
 export class DashboardService {
+    private userUrl = '/api/current_user'
+    constructor(private http: Http) {
+    console.log("Made a service");
+  }
+
+    getUser(): Promise<User> {
+      return this.http.get(this.userUrl)
+               .toPromise()
+               .then(response => response.json() as User)
+               .catch(this.handleError);
+    }
+
+    private extractData(res: Response) {
+        let body = res.json();
+        console.log("extracting data");
+        // console.log(body);
+        return body.data || {};
+    }
+
+    private handleError(error: Response | any) {
+        // In a real world app, we might use a remote logging infrastructure
+        let errMsg: string;
+        if (error instanceof Response) {
+            const body = error.json() || '';
+            const err = body.error || JSON.stringify(body);
+            errMsg = `${error.status} - ${error.statusText || ''} ${err}`;
+        } else {
+            errMsg = error.message ? error.message : error.toString();
+        }
+        console.error(errMsg);
+        return Observable.throw(errMsg);
+    }
+
 }

--- a/web/app/dashboard/user.ts
+++ b/web/app/dashboard/user.ts
@@ -1,8 +1,8 @@
 export class User {
   first_name: string;
-  user_name:string;
-  constructor(first_name:string,user_name:string){
+  username:string;
+  constructor(first_name:string,username:string){
     this.first_name = first_name;
-    this.user_name = user_name;
+    this.username = username;
   }
 }

--- a/web/views/partials/dashboard.html
+++ b/web/views/partials/dashboard.html
@@ -2,5 +2,9 @@
   Hey , {{user.first_name}}
 </h1>
 <h4>
-  you RCS ID is {{user.user_name}}
+  you RCS ID is {{user.username}}
 </h4>
+<p>
+  Data from the server is:
+  {{data}}
+</p>


### PR DESCRIPTION
**current_user**:
- Added service to fully consume /current_user
- May be beneficial to break this out into it's own module and service as the code base matures.

**get_shuttles**:
- As stated in [AJAX Security Cheat Sheet](https://www.owasp.org/index.php/AJAX_Security_Cheat_Sheet#Always_return_JSON_with_an_Object_on_the_outside) , it's insecure on older browsers to serve object scope arrays.
- Let's be pedantic and change any route returning an array to match this pattern.
- One possible other fix is making all routes match this pattern.
- This is also in line with how the official Angular documentation handles things.